### PR TITLE
Revamp IEnumerable(T) implementations

### DIFF
--- a/src/LinqToAStar/DefaultComparer.cs
+++ b/src/LinqToAStar/DefaultComparer.cs
@@ -44,7 +44,7 @@ namespace LinqToAStar
 
         public int Compare(TFactor x, TFactor y)
         {
-            return _descending ? 0 - _factorComparer.Compare(x, y) : _factorComparer.Compare(x, y);
+            return _descending ? _factorComparer.Compare(y, x) : _factorComparer.Compare(x, y);
         }
 
         #endregion

--- a/src/LinqToAStar/HeuristicSearchContains.cs
+++ b/src/LinqToAStar/HeuristicSearchContains.cs
@@ -33,25 +33,6 @@ namespace LinqToAStar
 
         #region Overrides
 
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return EnumerateFromSource().GetEnumerator();
-        }
-
-        #endregion
-
-        #region Others
-
-        private IEnumerable<TFactor> EnumerateFromSource()
-        {
-            if (_set == null)
-                _set = new HashSet<TFactor>(_collection, _comparer);
-
-            foreach (var r in Source)
-                if (_set.Contains(r))
-                    yield return r;
-        }
-
         private IEnumerable<TFactor> Convert(TStep step, int level)
         {
             if (_set == null)

--- a/src/LinqToAStar/HeuristicSearchExcept.cs
+++ b/src/LinqToAStar/HeuristicSearchExcept.cs
@@ -31,27 +31,8 @@ namespace LinqToAStar
 
         #endregion
 
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return EnumerateFromSource().GetEnumerator();
-        }
-
-        #endregion
-
         #region Others
-
-        private IEnumerable<TFactor> EnumerateFromSource()
-        {
-            if (_set == null)
-                _set = new HashSet<TFactor>(_collection, _comparer);
-
-            foreach (var r in Source)
-                if (!_set.Contains(r))
-                    yield return r;
-        }
-
+        
         private IEnumerable<TFactor> Convert(TStep step, int level)
         {
             if (_set == null)

--- a/src/LinqToAStar/HeuristicSearchOrderBy.cs
+++ b/src/LinqToAStar/HeuristicSearchOrderBy.cs
@@ -31,47 +31,6 @@ namespace LinqToAStar
 
         #endregion
 
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            Debug.WriteLine($"Searching path between {From} and {To} with {AlgorithmName}...");
-
-            var lastNode = default(Node<TFactor, TStep>);
-
-            switch (AlgorithmName)
-            {
-                case nameof(AStar):
-                    lastNode = AStar.Run(this);
-                    break;
-
-                case nameof(BestFirstSearch):
-                    lastNode = BestFirstSearch.Run(this);
-                    break;
-
-                case nameof(IterativeDeepeningAStar):
-                    lastNode = IterativeDeepeningAStar.Run(this);
-                    break;
-
-                case nameof(RecursiveBestFirstSearch):
-                    lastNode = RecursiveBestFirstSearch.Run(this);
-                    break;
-
-                default:
-                    lastNode = HeuristicSearch.RegisteredAlgorithms[AlgorithmName](AlgorithmName).Run(this);
-                    break;
-            }
-            if (lastNode == null) // Solution not found
-                return Enumerable.Empty<TFactor>().GetEnumerator();
-
-            if (IsReversed)
-                return lastNode.EnumerateReverseFactors().GetEnumerator();
-            else
-                return lastNode.TraceBack().EnumerateFactors().GetEnumerator();
-        }
-
-        #endregion
-
         #region IOrderedEnumerable<TFactor>
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, float> keySelector, bool descending)

--- a/src/LinqToAStar/HeuristicSearchSelect.cs
+++ b/src/LinqToAStar/HeuristicSearchSelect.cs
@@ -32,15 +32,6 @@ namespace LinqToAStar
 
         #endregion
 
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return _source.AsEnumerable().Select(_selector).GetEnumerator();
-        }
-
-        #endregion
-
         #region Others
 
         private IEnumerable<TFactor> Convert(TStep step, int level)

--- a/src/LinqToAStar/HeuristicSearchSelectMany.cs
+++ b/src/LinqToAStar/HeuristicSearchSelectMany.cs
@@ -35,15 +35,6 @@ namespace LinqToAStar
 
         #endregion
 
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return _source.AsEnumerable().SelectMany(_collectionSelector, _factorSelector).GetEnumerator();
-        }
-
-        #endregion
-
         #region Others
 
         private IEnumerable<TFactor> Convert(TStep step, int level)
@@ -80,15 +71,6 @@ namespace LinqToAStar
         {
             _source = source;
             _selector = selector;
-        }
-
-        #endregion
-
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return _source.AsEnumerable().SelectMany(_selector).GetEnumerator();
         }
 
         #endregion

--- a/src/LinqToAStar/HeuristicSearchWhere.cs
+++ b/src/LinqToAStar/HeuristicSearchWhere.cs
@@ -28,15 +28,6 @@ namespace LinqToAStar
 
         #endregion
 
-        #region Overrides
-
-        public override IEnumerator<TFactor> GetEnumerator()
-        {
-            return Source.AsEnumerable().Where(_predicate).GetEnumerator();
-        }
-
-        #endregion
-
         #region Others
 
         private IEnumerable<TFactor> Convert(TStep step, int level)

--- a/src/LinqToAStar/NormalComparer.cs
+++ b/src/LinqToAStar/NormalComparer.cs
@@ -46,9 +46,9 @@ namespace LinqToAStar
 
         public int Compare(TFactor x, TFactor y)
         {
-            var r = _keyComparer.Compare(_keySelector(x), _keySelector(y));
-
-            return _descending ? 0 - r : r;
+            return _descending ? 
+                _keyComparer.Compare(_keySelector(y), _keySelector(x)) : 
+                _keyComparer.Compare(_keySelector(x), _keySelector(y));
         }
 
         #endregion


### PR DESCRIPTION
1. Move all `IEnumerable(T)` implementations to `HeuristicSearchBase` class. 
2. Expose `Expand` and `ConvertToNodes` method.
3. Simplify `NormalComparer` and `DefaultComparer` comparison behavior.