### PR TITLE
Prevent unnecessary sorting in BFS

### DIFF
--- a/src/LinqToAStar.Test/ExpressionTest.cs
+++ b/src/LinqToAStar.Test/ExpressionTest.cs
@@ -1,22 +1,26 @@
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using Xunit;
 
 namespace LinqToAStar.Test
 {
+    using Core;
+
     public class ExpressionTest
     {
         private readonly Point start = new Point(2, 2);
         private readonly Point goal = new Point(18, 18);
-        private readonly Rectangle boundary = new Rectangle(0, 0, 20, 20);        
+        private readonly Rectangle boundary = new Rectangle(0, 0, 20, 20);
         private const int unit = 1;
 
-        [Fact]
-        public void LetTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void LetTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var solution = from step in queryable.Contains(boundary.GetAvailablePoints(unit))
                            let m = step.GetManhattanDistance(goal)
                            let e = step.GetChebyshevDistance(goal)
@@ -28,10 +32,14 @@ namespace LinqToAStar.Test
             Assert.Equal(actual.Last(), queryable.To);
         }
 
-        [Fact]
-        public void SelectManyTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void SelectManyTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
             var solution = from step in queryable
                            from obstacle in obstacles
@@ -45,10 +53,14 @@ namespace LinqToAStar.Test
             Assert.Equal(actual.Last(), queryable.To);
         }
 
-        [Fact]
-        public void ContainsTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void ContainsTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var solution = from step in queryable.Contains(boundary.GetAvailablePoints(unit))
                            orderby step.GetManhattanDistance(goal)
                            select step;
@@ -58,10 +70,14 @@ namespace LinqToAStar.Test
             Assert.Equal(actual.Last(), queryable.To);
         }
 
-        [Fact]
-        public void ReverseFromInsideTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void ReverseFromInsideTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var solution = from step in queryable.Reverse()
                            where boundary.Contains(step)
                            orderby step.GetManhattanDistance(goal)
@@ -72,10 +88,14 @@ namespace LinqToAStar.Test
             Assert.Equal(actual.Last(), queryable.From);
         }
 
-        [Fact]
-        public void ReverseFromOutsideTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void ReverseFromOutsideTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var solution = from step in queryable
                            where boundary.Contains(step)
                            orderby step.GetManhattanDistance(goal)
@@ -86,10 +106,14 @@ namespace LinqToAStar.Test
             Assert.Equal(actual.Last(), queryable.From);
         }
 
-        [Fact]
-        public void OrderByThenByComparerTest()
+        [Theory]
+        [InlineData(nameof(AStar))]
+        [InlineData(nameof(BestFirstSearch))]
+        [InlineData(nameof(IterativeDeepeningAStar))]
+        [InlineData(nameof(RecursiveBestFirstSearch))]
+        public void OrderByThenByComparerTest(string algorithmName)
         {
-            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var queryable = HeuristicSearch.Use(algorithmName, start, goal, (step, lv) => step.GetFourDirections(unit));
             var solution = from step in queryable
                            where boundary.Contains(step)
                            orderby step.GetManhattanDistance(goal), step.GetEuclideanDistance(goal)

--- a/src/LinqToAStar/Core/AStar.cs
+++ b/src/LinqToAStar/Core/AStar.cs
@@ -38,13 +38,13 @@ namespace LinqToAStar.Core
                     if (open.Find(step => sc.Equals(next.Step, step.Step)) == null)
                     {
                         next.Previous = current;
-                        
+
                         if (sc.Equals(next.Step, source.To))
                             return next;
 
                         sortAll = sortAll || nc.Compare(open[open.Count - 1], next) > 0;
                         open.Add(next);
-                    
+
                         Debug.WriteLine($"{current.Step}\t{current.Level} -> {next.Step}\t{next.Level}");
                     }
                 }
@@ -52,6 +52,16 @@ namespace LinqToAStar.Core
                     open.Sort(sortAt, open.Count - sortAt, nc);
             }
             return null;
+        }
+    }
+
+    internal struct AStarAlgorithm : IAlgorithm
+    {
+        string IAlgorithm.AlgorithmName => nameof(AStar);
+
+        Node<TFactor, TStep> IAlgorithm.Run<TFactor, TStep>(HeuristicSearchBase<TFactor, TStep> source)
+        {
+            return AStar.Run(source);
         }
     }
 }

--- a/src/LinqToAStar/Core/BestFirstSearch.cs
+++ b/src/LinqToAStar/Core/BestFirstSearch.cs
@@ -9,36 +9,52 @@ namespace LinqToAStar.Core
         {
             Debug.WriteLine("LINQ Expression Stack: {0}", source);
 
+            var nc = source.NodeComparer.FactorOnlyComparer;
+            var sc = source.StepComparer;
             var nexts = new List<Node<TFactor, TStep>>(source.ConvertToNodes(source.From, 0));
 
             if (nexts.Count == 0)
                 return null;
 
-            var visited = new HashSet<TStep>(source.StepComparer);
+            var visited = new HashSet<TStep>(sc);
             var sortAt = 0;
 
             while (nexts.Count - sortAt > 0)
             {
                 var best = nexts[sortAt]; // nexts.First();
-                var hasNext = false;
+                var sortAll = false;
 
-                if (source.StepComparer.Equals(best.Step, source.To))
+                if (sc.Equals(best.Step, source.To))
                     return best;
 
                 sortAt++; // nexts.RemoveAt(0);
 
                 foreach (var next in source.Expands(best.Step, best.Level, visited.Add))
                 {
-                    Debug.WriteLine($"{best.Step}\t{best.Level} -> {next.Step}\t{next.Level}");
-
                     next.Previous = best;
+
+                    if (sc.Equals(next.Step, source.To))
+                        return next;
+
+                    sortAll = sortAll || nc.Compare(nexts[nexts.Count - 1], next) > 0;
                     nexts.Add(next);
-                    hasNext = true;
+
+                    Debug.WriteLine($"{best.Step}\t{best.Level} -> {next.Step}\t{next.Level}");
                 }
-                if (hasNext)
-                    nexts.Sort(sortAt, nexts.Count - sortAt, source.NodeComparer.FactorOnlyComparer);
+                if (sortAll)
+                    nexts.Sort(sortAt, nexts.Count - sortAt, nc);
             }
             return null;
+        }
+    }
+
+    internal struct BestFirstSearchrAlgorithm : IAlgorithm
+    {
+        string IAlgorithm.AlgorithmName => nameof(BestFirstSearch);
+
+        Node<TFactor, TStep> IAlgorithm.Run<TFactor, TStep>(HeuristicSearchBase<TFactor, TStep> source)
+        {
+            return BestFirstSearch.Run(source);
         }
     }
 }

--- a/src/LinqToAStar/Core/IterativeDeepeningAStar.cs
+++ b/src/LinqToAStar/Core/IterativeDeepeningAStar.cs
@@ -105,4 +105,16 @@ namespace LinqToAStar.Core
 
         #endregion 
     }
+
+    internal struct IterativeDeepeningAStarAlgorithm : IAlgorithm
+    {
+        string IAlgorithm.AlgorithmName => nameof(IterativeDeepeningAStar);
+
+        Node<TFactor, TStep> IAlgorithm.Run<TFactor, TStep>(HeuristicSearchBase<TFactor, TStep> source)
+        {
+            Debug.WriteLine("LINQ Expression Stack: {0}", source);
+
+            return new IterativeDeepeningAStar<TFactor, TStep>(source).Run();
+        }
+    }
 }

--- a/src/LinqToAStar/Core/RecursiveBestFirstSearch.cs
+++ b/src/LinqToAStar/Core/RecursiveBestFirstSearch.cs
@@ -102,4 +102,16 @@ namespace LinqToAStar.Core
 
         #endregion 
     }
+
+    internal struct RecursiveBestFirstSearchAlgorithm : IAlgorithm
+    {
+        string IAlgorithm.AlgorithmName => nameof(RecursiveBestFirstSearch);
+
+        Node<TFactor, TStep> IAlgorithm.Run<TFactor, TStep>(HeuristicSearchBase<TFactor, TStep> source)
+        {
+            Debug.WriteLine("LINQ Expression Stack: {0}", source);
+
+            return new RecursiveBestFirstSearch<TFactor, TStep>(source).Run();
+        }
+    }
 }

--- a/src/LinqToAStar/HeuristicSearch.cs
+++ b/src/LinqToAStar/HeuristicSearch.cs
@@ -3,10 +3,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleToAttribute("LinqToAStar.Test")]
+[assembly:InternalsVisibleTo("LinqToAStar.Test")]
 
 namespace LinqToAStar
 {
+    using Core;
+
     /// <summary>
     /// Provides a set of static methods to initialize <see cref="HeuristicSearchBase{TFactor, TStep}"/> instance with specific algorithm.
     /// </summary>
@@ -14,7 +16,23 @@ namespace LinqToAStar
     {
         #region Fields
 
-        private readonly static ConcurrentDictionary<string, Func<string, IAlgorithm>> algorithms = new ConcurrentDictionary<string, Func<string, IAlgorithm>>();
+        private readonly static ConcurrentDictionary<string, Func<string, IAlgorithm>> algorithms;
+
+        #endregion
+
+        #region Constructor
+
+        static HeuristicSearch()
+        {
+            var presets = new[]
+            {
+                new KeyValuePair<string, Func<string, IAlgorithm>>(nameof(AStar), (n) => new AStarAlgorithm()),
+                new KeyValuePair<string, Func<string, IAlgorithm>>(nameof(BestFirstSearch), (n) => new BestFirstSearchrAlgorithm()),
+                new KeyValuePair<string, Func<string, IAlgorithm>>(nameof(IterativeDeepeningAStar), (n) => new IterativeDeepeningAStarAlgorithm()),
+                new KeyValuePair<string, Func<string, IAlgorithm>>(nameof(RecursiveBestFirstSearch), (n) => new RecursiveBestFirstSearchAlgorithm()),
+            };
+            algorithms = new ConcurrentDictionary<string, Func<string, IAlgorithm>>(presets);
+        }
 
         #endregion
 


### PR DESCRIPTION
Also including following changes:

1. Add preset algorithms to HeuristicSearch.RegisteredAlgorithms properties.
2. Update expression test cases. Test cases now cover all algorithms.