### PR TITLE
Improve Exception Message

### DIFF
--- a/src/Heuristic.Linq.Test/ExceptionTest.cs
+++ b/src/Heuristic.Linq.Test/ExceptionTest.cs
@@ -1,0 +1,32 @@
+using System.Drawing;
+using System.Linq;
+using Xunit;
+
+namespace Heuristic.Linq.Test
+{
+    using System;
+    using Algorithms;
+
+    public class ExceptionTest
+    {
+        private readonly Point start = new Point(2, 2);
+        private readonly Point goal = new Point(18, 18);
+        private readonly Rectangle boundary = new Rectangle(0, 0, 20, 20);
+        private const int unit = 1;
+
+        [Fact]
+        public void InvalidOperationExceptionTest()
+        {
+            var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
+            var solution = from step in queryable
+                           from obstacle in obstacles
+                           where step != obstacle
+                           select step;
+            
+            var exception = Assert.Throws<InvalidOperationException>(() => solution.First());
+
+            Assert.StartsWith("Unable to evaluate steps.", exception.Message);
+        }
+    }
+}

--- a/src/Heuristic.Linq/Extensions.cs
+++ b/src/Heuristic.Linq/Extensions.cs
@@ -380,6 +380,9 @@ namespace Heuristic.Linq
 
         internal static Node<TFactor, TStep> Run<TFactor, TStep>(this HeuristicSearchBase<TFactor, TStep> source)
         {
+            if (source.NodeComparer == null && !HeuristicSearchBase<TFactor, TStep>.IsFactorComparable)
+                throw new InvalidOperationException($"Unable to evaluate steps. The orderby clause is missing or {typeof(TFactor)} does not implement {typeof(IComparable<TFactor>)}.");
+
             Debug.WriteLine($"Searching path between {source.From} and {source.To} with {source.AlgorithmName}...");
 
             var lastNode = default(Node<TFactor, TStep>);

--- a/src/Heuristic.Linq/HeuristicSearchBase.cs
+++ b/src/Heuristic.Linq/HeuristicSearchBase.cs
@@ -52,7 +52,7 @@ namespace Heuristic.Linq
         /// </summary>
         public INodeComparer<TFactor, TStep> NodeComparer => _nc;
 
-        internal bool IsReversed { get; set; }
+        internal bool IsReversed { get; set; } // Consider exposing this.
 
         internal Func<TStep, int, IEnumerable<TStep>> Expander => _expander;
 

--- a/src/Heuristic.Linq/HeuristicSearchInitial.cs
+++ b/src/Heuristic.Linq/HeuristicSearchInitial.cs
@@ -10,22 +10,13 @@ namespace Heuristic.Linq
 
         public static readonly Func<TStep, int, IEnumerable<TStep>> EmptyConverter = (s, t) => Enumerable.Repeat(s, 1);
 
-        private readonly string _algorithmName = string.Empty;
-
-        #endregion
-
-        #region Properties
-
-        public override string AlgorithmName => _algorithmName;
-
         #endregion
 
         #region Constructors
 
         internal HeuristicSearchInitial(string algorithmName, TStep from, TStep to, IEqualityComparer<TStep> comparer, Func<TStep, int, IEnumerable<TStep>> expander)
-            : base(from, to, comparer, EmptyConverter, expander)
+            : base(algorithmName, from, to, comparer, null, EmptyConverter, expander)
         {
-            _algorithmName = algorithmName;
         }
 
         #endregion

--- a/src/Heuristic.Linq/HeuristicSearchOrderBy.cs
+++ b/src/Heuristic.Linq/HeuristicSearchOrderBy.cs
@@ -16,6 +16,7 @@ namespace Heuristic.Linq
         internal HeuristicSearchOrderBy(HeuristicSearchBase<TFactor, TStep> source, INodeComparer<TFactor, TStep> nodeComparer)
             : base(source.AlgorithmName, source.From, source.To, source.StepComparer, nodeComparer, source.Converter, source.Expander)
         {
+            IsReversed = source.IsReversed;
         }
 
         #endregion

--- a/src/Heuristic.Linq/HeuristicSearchOrderBy.cs
+++ b/src/Heuristic.Linq/HeuristicSearchOrderBy.cs
@@ -11,27 +11,11 @@ namespace Heuristic.Linq
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public class HeuristicSearchOrderBy<TFactor, TStep> : HeuristicSearchBase<TFactor, TStep>, IOrderedEnumerable<TFactor>
     {
-        #region Fields
-
-        private INodeComparer<TFactor, TStep> _nodeComparer;
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Gets the comparer used to compare two <see cref="Node{TFactor, TStep}"/> instances.
-        /// </summary>
-        public override INodeComparer<TFactor, TStep> NodeComparer => _nodeComparer;
-
-        #endregion
-
         #region Constructors
 
         internal HeuristicSearchOrderBy(HeuristicSearchBase<TFactor, TStep> source, INodeComparer<TFactor, TStep> nodeComparer)
-            : base(source)
+            : base(source.AlgorithmName, source.From, source.To, source.StepComparer, nodeComparer, source.Converter, source.Expander)
         {
-            _nodeComparer = nodeComparer;
         }
 
         #endregion
@@ -42,144 +26,120 @@ namespace Heuristic.Linq
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, double> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, decimal> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, byte> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, sbyte> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, short> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, ushort> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, int> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, uint> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, long> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable(Func<TFactor, ulong> keySelector, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new HeuristicComparer<TFactor, TStep>(keySelector, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         internal HeuristicSearchOrderBy<TFactor, TStep> CreateOrderedEnumerable<TKey>(Func<TFactor, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var comparer1 = _nodeComparer;
+            var comparer1 = NodeComparer;
             var comparer2 = new NormalComparer<TFactor, TKey, TStep>(keySelector, null, descending);
 
-            _nodeComparer = new CombinedComparer<TFactor, TStep>(comparer1, comparer2);
-
-            return this;
+            return new HeuristicSearchOrderBy<TFactor, TStep>(this, new CombinedComparer<TFactor, TStep>(comparer1, comparer2));
         }
 
         IOrderedEnumerable<TFactor> IOrderedEnumerable<TFactor>.CreateOrderedEnumerable<TKey>(Func<TFactor, TKey> keySelector, IComparer<TKey> comparer, bool descending)

--- a/src/Heuristic.Linq/HeuristicSearchSelect.cs
+++ b/src/Heuristic.Linq/HeuristicSearchSelect.cs
@@ -26,6 +26,8 @@ namespace Heuristic.Linq
         {
             _source = source;
             _selector = selector;
+
+            IsReversed = source.IsReversed;
         }
 
         #endregion

--- a/src/Heuristic.Linq/HeuristicSearchSelect.cs
+++ b/src/Heuristic.Linq/HeuristicSearchSelect.cs
@@ -14,9 +14,7 @@ namespace Heuristic.Linq
         #endregion
 
         #region Properties
-
-        public override string AlgorithmName => _source.AlgorithmName;
-
+         
         internal override Func<TStep, int, IEnumerable<TFactor>> Converter => Convert;
 
         #endregion
@@ -24,7 +22,7 @@ namespace Heuristic.Linq
         #region Constructor
 
         public HeuristicSearchSelect(HeuristicSearchBase<TSource, TStep> source, Func<TSource, int, TFactor> selector)
-            : base(source.From, source.To, source.StepComparer, source.Expander)
+            : base(source.AlgorithmName, source.From, source.To, source.StepComparer, null, null, source.Expander)
         {
             _source = source;
             _selector = selector;

--- a/src/Heuristic.Linq/HeuristicSearchSelectMany.cs
+++ b/src/Heuristic.Linq/HeuristicSearchSelectMany.cs
@@ -29,6 +29,8 @@ namespace Heuristic.Linq
             _source = source;
             _collectionSelector = collectionSelector;
             _factorSelector = factorSelector;
+
+            IsReversed = source.IsReversed;
         }
 
         #endregion
@@ -94,6 +96,8 @@ namespace Heuristic.Linq
         {
             _source = source;
             _selector = selector;
+
+            IsReversed = source.IsReversed;
         }
 
         #endregion

--- a/src/Heuristic.Linq/HeuristicSearchSelectMany.cs
+++ b/src/Heuristic.Linq/HeuristicSearchSelectMany.cs
@@ -16,8 +16,6 @@ namespace Heuristic.Linq
 
         #region Properties
 
-        public override string AlgorithmName => _source.AlgorithmName;
-
         internal override Func<TStep, int, IEnumerable<TFactor>> Converter => Convert;
 
         #endregion
@@ -26,7 +24,7 @@ namespace Heuristic.Linq
 
         internal HeuristicSearchSelectMany(HeuristicSearchBase<TSource, TStep> source,
             Func<TSource, int, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TFactor> factorSelector)
-            : base(source.From, source.To, source.StepComparer, source.Expander)
+            : base(source.AlgorithmName, source.From, source.To, source.StepComparer, null, null, source.Expander)
         {
             _source = source;
             _collectionSelector = collectionSelector;
@@ -85,8 +83,6 @@ namespace Heuristic.Linq
 
         #region Properties
 
-        public override string AlgorithmName => _source.AlgorithmName;
-
         internal override Func<TStep, int, IEnumerable<TFactor>> Converter => Convert;
 
         #endregion
@@ -94,7 +90,7 @@ namespace Heuristic.Linq
         #region Constructors
 
         internal HeuristicSearchSelectMany(HeuristicSearchBase<TSource, TStep> source, Func<TSource, int, IEnumerable<TFactor>> selector)
-            : base(source.From, source.To, source.StepComparer, source.Expander)
+            : base(source.AlgorithmName, source.From, source.To, source.StepComparer, null, null, source.Expander)
         {
             _source = source;
             _selector = selector;


### PR DESCRIPTION
1. Now `InvalidOperationException` will be thrown if `orderby` clause is not given or `TStep` is not comparable.
2. Consolidate internal constructors.
3. Add exception test case.