### PR TITLE
Change default comparison behavior

### DIFF
--- a/src/Heuristic.Linq.Test/ExceptionTest.cs
+++ b/src/Heuristic.Linq.Test/ExceptionTest.cs
@@ -1,11 +1,10 @@
+using System;
 using System.Drawing;
 using System.Linq;
 using Xunit;
 
 namespace Heuristic.Linq.Test
 {
-    using System;
-    using Algorithms;
 
     public class ExceptionTest
     {
@@ -15,7 +14,7 @@ namespace Heuristic.Linq.Test
         private const int unit = 1;
 
         [Fact]
-        public void InvalidOperationExceptionTest()
+        public void AStarWithoutOrderByTest()
         {
             var queryable = HeuristicSearch.AStar(start, goal, (step, lv) => step.GetFourDirections(unit));
             var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
@@ -23,8 +22,52 @@ namespace Heuristic.Linq.Test
                            from obstacle in obstacles
                            where step != obstacle
                            select step;
-            
-            var exception = Assert.Throws<InvalidOperationException>(() => solution.First());
+            var actual = solution.ToList();
+
+            Assert.Equal(actual.First(), queryable.From);
+            Assert.Equal(actual.Last(), queryable.To);
+        }
+
+        [Fact]
+        public void IDAStarWithoutOrderByTest()
+        {
+            var queryable = HeuristicSearch.IterativeDeepeningAStar(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
+            var solution = from step in queryable
+                           from obstacle in obstacles
+                           where step != obstacle
+                           select step;
+            var exception = Assert.Throws<InvalidOperationException>(() => solution.ToList());
+
+            Assert.StartsWith("Unable to evaluate steps.", exception.Message);
+        }
+
+        [Fact]
+        public void BFSWithoutOrderByTest()
+        {
+            var queryable = HeuristicSearch.BestFirstSearch(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
+            var solution = from step in queryable
+                           from obstacle in obstacles
+                           where step != obstacle
+                           select step;
+
+            var exception = Assert.Throws<InvalidOperationException>(() => solution.ToList());
+
+            Assert.StartsWith("Unable to evaluate steps.", exception.Message);
+        }
+
+        [Fact]
+        public void RBFSWithoutOrderByTest()
+        {
+            var queryable = HeuristicSearch.RecursiveBestFirstSearch(start, goal, (step, lv) => step.GetFourDirections(unit));
+            var obstacles = new[] { new Point(5, 5), new Point(6, 6), new Point(7, 7), new Point(8, 8), new Point(9, 9) };
+            var solution = from step in queryable
+                           from obstacle in obstacles
+                           where step != obstacle
+                           select step;
+
+            var exception = Assert.Throws<InvalidOperationException>(() => solution.ToList());
 
             Assert.StartsWith("Unable to evaluate steps.", exception.Message);
         }

--- a/src/Heuristic.Linq/Algorithms/RecursiveBestFirstSearch.cs
+++ b/src/Heuristic.Linq/Algorithms/RecursiveBestFirstSearch.cs
@@ -43,7 +43,14 @@ namespace Heuristic.Linq.Algorithms
             if (inits.Length == 0)
                 return null;
 
-            Array.Sort(inits, _nodeComparer);
+            try
+            {
+                Array.Sort(inits, _nodeComparer);
+            }
+            catch (Exception error)
+            {
+                throw error.InnerException ?? error;
+            }
 
             var best = inits[0];
             var state = Search(best, null, new HashSet<TStep>(_source.StepComparer));

--- a/src/Heuristic.Linq/DefaultComparer.cs
+++ b/src/Heuristic.Linq/DefaultComparer.cs
@@ -22,12 +22,10 @@ namespace Heuristic.Linq
 
         public DefaultComparer() : this(false) { }
 
-        public DefaultComparer(bool descending) : this(null, false) { }
-
-        public DefaultComparer(IComparer<TFactor> factorComparer, bool descending)
+        public DefaultComparer(bool descending)
         {
             _descending = descending;
-            _factorComparer = factorComparer ?? (HeuristicSearchBase<TFactor, TStep>.IsFactorComparable ? Comparer<TFactor>.Default : null);
+            _factorComparer = HeuristicSearchBase<TFactor, TStep>.IsFactorComparable ? Comparer<TFactor>.Default : null;
         }
 
         #endregion

--- a/src/Heuristic.Linq/DefaultComparer.cs
+++ b/src/Heuristic.Linq/DefaultComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Heuristic.Linq
@@ -8,13 +9,12 @@ namespace Heuristic.Linq
 
         private readonly bool _descending;
         private readonly IComparer<TFactor> _factorComparer;
-        private readonly IComparer<Node<TFactor, TStep>> _factorOnlyComparer;
 
         #endregion
 
         #region Properties
 
-        public IComparer<Node<TFactor, TStep>> FactorOnlyComparer => _factorOnlyComparer;
+        public IComparer<Node<TFactor, TStep>> FactorOnlyComparer => Comparer<Node<TFactor, TStep>>.Create(CompareFactorOnly);
 
         #endregion
 
@@ -27,8 +27,7 @@ namespace Heuristic.Linq
         public DefaultComparer(IComparer<TFactor> factorComparer, bool descending)
         {
             _descending = descending;
-            _factorComparer = factorComparer ?? Comparer<TFactor>.Default;
-            _factorOnlyComparer = Comparer<Node<TFactor, TStep>>.Create(CompareFactorOnly);
+            _factorComparer = factorComparer ?? (HeuristicSearchBase<TFactor, TStep>.IsFactorComparable ? Comparer<TFactor>.Default : null);
         }
 
         #endregion
@@ -37,13 +36,22 @@ namespace Heuristic.Linq
 
         public int Compare(Node<TFactor, TStep> x, Node<TFactor, TStep> y)
         {
-            var r = CompareFactorOnly(x, y);
+            if (x == null) return y == null ? 0 : 1;
+            if (y == null) return -1;
+
+            var r = 0;
+
+            if (_factorComparer != null)
+                r = _descending ? _factorComparer.Compare(y.Factor, x.Factor) : _factorComparer.Compare(x.Factor, y.Factor);
 
             return r != 0 ? r : DistanceHelper.Int32Comparer.Compare(x.Level, y.Level);
         }
 
         public int Compare(TFactor x, TFactor y)
         {
+            if (_factorComparer == null)
+                throw new InvalidOperationException($"Unable to evaluate steps. The orderby clause is missing or {typeof(TFactor)} does not implement {typeof(IComparable<TFactor>)}.");
+
             return _descending ? _factorComparer.Compare(y, x) : _factorComparer.Compare(x, y);
         }
 
@@ -56,7 +64,7 @@ namespace Heuristic.Linq
             if (x == null) return y == null ? 0 : 1;
             if (y == null) return -1;
 
-            return Compare(x.Factor, y.Factor);
+            return Compare(y.Factor, x.Factor);
         }
 
         #endregion

--- a/src/Heuristic.Linq/Extensions.cs
+++ b/src/Heuristic.Linq/Extensions.cs
@@ -395,9 +395,6 @@ namespace Heuristic.Linq
 
         internal static Node<TFactor, TStep> Run<TFactor, TStep>(this HeuristicSearchBase<TFactor, TStep> source)
         {
-            // if (source.NodeComparer == null && !HeuristicSearchBase<TFactor, TStep>.IsFactorComparable)
-            //    throw new InvalidOperationException($"Unable to evaluate steps. The orderby clause is missing or {typeof(TFactor)} does not implement {typeof(IComparable<TFactor>)}.");
-
             Debug.WriteLine($"Searching path between {source.From} and {source.To} with {source.AlgorithmName}...");
 
             var lastNode = default(Node<TFactor, TStep>);

--- a/src/Heuristic.Linq/Extensions.cs
+++ b/src/Heuristic.Linq/Extensions.cs
@@ -395,8 +395,8 @@ namespace Heuristic.Linq
 
         internal static Node<TFactor, TStep> Run<TFactor, TStep>(this HeuristicSearchBase<TFactor, TStep> source)
         {
-            if (source.NodeComparer == null && !HeuristicSearchBase<TFactor, TStep>.IsFactorComparable)
-                throw new InvalidOperationException($"Unable to evaluate steps. The orderby clause is missing or {typeof(TFactor)} does not implement {typeof(IComparable<TFactor>)}.");
+            // if (source.NodeComparer == null && !HeuristicSearchBase<TFactor, TStep>.IsFactorComparable)
+            //    throw new InvalidOperationException($"Unable to evaluate steps. The orderby clause is missing or {typeof(TFactor)} does not implement {typeof(IComparable<TFactor>)}.");
 
             Debug.WriteLine($"Searching path between {source.From} and {source.To} with {source.AlgorithmName}...");
 

--- a/src/Heuristic.Linq/HeuristicSearchBase.cs
+++ b/src/Heuristic.Linq/HeuristicSearchBase.cs
@@ -81,7 +81,7 @@ namespace Heuristic.Linq
 
             _algorithmName = algorithmName;
             _ec = ec ?? EqualityComparer<TStep>.Default;
-            _nc = nc != null ? nc : (IsFactorComparable ? new DefaultComparer<TFactor, TStep>() : null);
+            _nc = nc != null ? nc : new DefaultComparer<TFactor, TStep>();
             _converter = converter;
             _expander = expander ?? throw new ArgumentNullException(nameof(expander));
         }


### PR DESCRIPTION
1. If `orderby` clause is not given and `TFactor` does not implement `IComparable<TFactor>` interface, only _g(n)_ will be used to compare. For algorithms that need _h(n)_ will throw `InvalidOperationException`.
2. Add test cases.