### PR TITLE
Fix incorrect modifiers on Event Handler

### DIFF
--- a/src/Heuristic.Linq/AlgorithmObserverFactory.cs
+++ b/src/Heuristic.Linq/AlgorithmObserverFactory.cs
@@ -13,7 +13,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Invoked when a new <see cref="AlgorithmProgress{TStep}"/> instance is created.
         /// </summary>
-        public readonly EventHandler<AlgorithmProgress<TStep>> Created;
+        public event EventHandler<AlgorithmProgress<TStep>> Created;
 
         /// <summary>
         /// Initializes a new instance of current class.

--- a/src/Heuristic.Linq/AlgorithmProgress.cs
+++ b/src/Heuristic.Linq/AlgorithmProgress.cs
@@ -13,7 +13,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Invoked when the progress of an algorithm has changed.
         /// </summary>
-        public EventHandler<IAlgorithmState<TStep>> ProgressChanged;
+        public event EventHandler<IAlgorithmState<TStep>> ProgressChanged;
 
         void IProgress<IAlgorithmState<TStep>>.Report(IAlgorithmState<TStep> value)
         {

--- a/src/Heuristic.Linq/Algorithms/AlgorithmState.cs
+++ b/src/Heuristic.Linq/Algorithms/AlgorithmState.cs
@@ -6,7 +6,7 @@ namespace Heuristic.Linq.Algorithms
     /// <summary>
     /// Represents the state of an algorithm.
     /// </summary>
-    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public struct AlgorithmState<TFactor, TStep> : IAlgorithmState<TStep>
     {

--- a/src/Heuristic.Linq/Extensions.cs
+++ b/src/Heuristic.Linq/Extensions.cs
@@ -15,7 +15,7 @@ namespace Heuristic.Linq
         /// Select the factor used to evaluate with heuristic functions.
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="selector">The selector to select factor from current instance.</param>
@@ -33,7 +33,7 @@ namespace Heuristic.Linq
         /// Select the factor used to evaluate with heuristic functions.
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="selector">The selector with index argument to select factor from current instance.</param>
@@ -51,7 +51,7 @@ namespace Heuristic.Linq
         /// Select one or more factors used to evaluate with heuristic functions.
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="selector">The selector to select factor from current instance.</param>
@@ -70,7 +70,7 @@ namespace Heuristic.Linq
         /// Select one or more factors used to evaluate with heuristic functions.
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="selector">The selector with index argument to select factor from current instance.</param>
@@ -90,7 +90,7 @@ namespace Heuristic.Linq
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
         /// <typeparam name="TCollection">The type of the intermediate elements collected by the function represented by <paramref name="collectionSelector"/>.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collectionSelector">A projection function to apply to each element of the source.</param>
@@ -112,7 +112,7 @@ namespace Heuristic.Linq
         /// </summary>
         /// <typeparam name="TSource">The source type of factor used to evaluate with heuristic function.</typeparam>
         /// <typeparam name="TCollection">The type of the intermediate elements collected by the function represented by <paramref name="collectionSelector"/>.</typeparam>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collectionSelector">A projection function to apply to each element of the source.</param>
@@ -132,7 +132,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply filter to current instance. 
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="predicate">A function to test each source element for a condition.</param>
@@ -149,7 +149,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply filter to current instance. 
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="predicate">A function to test each source element and its index for a condition.</param>
@@ -166,7 +166,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply black-listing filter to current instance by giving a <typeparamref name="TStep"/> collection.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collection">The collection as filter condition.</param>
@@ -183,7 +183,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply black-listing  filter to current instance by giving a <typeparamref name="TStep"/> collection and specific comparer.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collection">The collection as filter condition.</param>
@@ -201,7 +201,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply white-listing filter to current instance by giving a <typeparamref name="TStep"/> collection.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collection">The collection as filter condition.</param>
@@ -218,7 +218,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Apply white-listing  filter to current instance by giving a <typeparamref name="TStep"/> collection and specific comparer.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="collection">The collection as filter condition.</param>
@@ -237,7 +237,7 @@ namespace Heuristic.Linq
         /// Inverts the order of solution from <see cref="HeuristicSearchBase{TFactor, TStep}.From"/> to <see cref="HeuristicSearchBase{TFactor, TStep}.To"/> 
         /// to <see cref="HeuristicSearchBase{TFactor, TStep}.To"/> to <see cref="HeuristicSearchBase{TFactor, TStep}.From"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>An instance with type <typeparamref name="TFactor"/> as factor.</returns>
@@ -254,7 +254,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Determines whether the solution can be found.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>true if the solution can be found; otherwise, false.</returns>
@@ -272,7 +272,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns the number of steps in solution.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The number of steps in solution.</returns>
@@ -292,7 +292,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns the number of steps in solution, in <see cref="Int64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The number of steps in solution.</returns>
@@ -312,7 +312,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns first step of the solution.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The first step of the solution.</returns>
@@ -332,7 +332,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns first step of the solution, or default value of <typeparamref name="TFactor"/> if solution is not found.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The first step of the solution.</returns>
@@ -354,7 +354,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns last step of the solution.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The last step of the solution.</returns>
@@ -374,7 +374,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Returns last step of the solution, or default value of <typeparamref name="TFactor"/> if solution is not found.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <returns>The last step of the solution.</returns>

--- a/src/Heuristic.Linq/ExtensionsOrderBy.cs
+++ b/src/Heuristic.Linq/ExtensionsOrderBy.cs
@@ -10,7 +10,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Single"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -27,7 +27,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Double"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -44,7 +44,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Decimal"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -61,7 +61,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Byte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -78,7 +78,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="SByte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -95,7 +95,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Int16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -112,7 +112,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="UInt16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -129,7 +129,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Int32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -146,7 +146,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="UInt32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -163,7 +163,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="Int64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -180,7 +180,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <see cref="UInt64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -197,7 +197,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -215,7 +215,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -238,7 +238,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Single"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -255,7 +255,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Double"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -272,7 +272,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Decimal"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -289,7 +289,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Byte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -306,7 +306,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="SByte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -323,7 +323,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Int16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -340,7 +340,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="UInt16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -357,7 +357,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Int32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -374,7 +374,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="UInt32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -391,7 +391,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="Int64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -408,7 +408,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <see cref="UInt64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -425,7 +425,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -440,7 +440,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies descending heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -463,7 +463,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Single"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -479,7 +479,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Double"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -495,7 +495,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Decimal"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -511,7 +511,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Byte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -527,7 +527,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="SByte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -543,7 +543,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Int16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -559,7 +559,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="UInt16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -575,7 +575,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Int32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -591,7 +591,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="UInt32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -607,7 +607,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="Int64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -623,7 +623,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <see cref="UInt64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -639,7 +639,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -654,7 +654,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -676,7 +676,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Single"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -692,7 +692,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Double"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -708,7 +708,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Decimal"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -724,7 +724,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Byte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -740,7 +740,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="SByte"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -756,7 +756,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Int16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -772,7 +772,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="UInt16"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -788,7 +788,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Int32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -804,7 +804,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="UInt32"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -820,7 +820,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="Int64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -836,7 +836,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <see cref="UInt64"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>
         /// <param name="keySelector">The heuristic function to estimate and compare <typeparamref name="TFactor"/>.</param>
@@ -852,7 +852,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <param name="source">The current instance.</param>
@@ -867,7 +867,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Applies a subsequent descending heuristic function to current instance. The return type is <typeparamref name="TKey"/>.
         /// </summary>
-        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+        /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
         /// <typeparam name="TKey">The return type of heuristic function.</typeparam>
         /// <typeparam name="TStep">The type of step of the problem.</typeparam>
         /// <param name="source">The current instance.</param>

--- a/src/Heuristic.Linq/HeuristicSearchBase.cs
+++ b/src/Heuristic.Linq/HeuristicSearchBase.cs
@@ -8,7 +8,7 @@ namespace Heuristic.Linq
     /// <summary>
     /// Defines the instance that allows LINQ expressions to be applied to heuristic algorithms.
     /// </summary>
-    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public abstract class HeuristicSearchBase<TFactor, TStep> : IEnumerable<TFactor>
     {

--- a/src/Heuristic.Linq/IAlgorithmObserverFactory.cs
+++ b/src/Heuristic.Linq/IAlgorithmObserverFactory.cs
@@ -15,6 +15,9 @@ namespace Heuristic.Linq
         /// </summary>
         /// <param name="source">The instance that allows LINQ expressions to be applied to.</param>
         /// <returns>An <see cref="IProgress{T}"/> instance.</returns>
+        /// <remarks>
+        /// Mo 
+        /// <remarks>
         IProgress<AlgorithmState<TFactor, TStep>> Create<TFactor>(HeuristicSearchBase<TFactor, TStep> source);
     }
 }

--- a/src/Heuristic.Linq/INodeComparer.cs
+++ b/src/Heuristic.Linq/INodeComparer.cs
@@ -5,7 +5,7 @@ namespace Heuristic.Linq
     /// <summary>
     /// Defines the comparer used to compare two <see cref="Node{TFactor, TStep}"/> instances. 
     /// </summary>
-    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public interface INodeComparer<TFactor, TStep> : IComparer<Node<TFactor, TStep>>, IComparer<TFactor>
     {

--- a/src/Heuristic.Linq/Node.cs
+++ b/src/Heuristic.Linq/Node.cs
@@ -6,7 +6,7 @@ namespace Heuristic.Linq
     /// <summary>
     /// Defines a node that represents specific step and its corresponding level of the problem.
     /// </summary>
-    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function.</typeparam>
+    /// <typeparam name="TFactor">The type of factor used to evaluate with heuristic function. The type is projected from <typeparamref name="TStep"/>.</typeparam>
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public class Node<TFactor, TStep> : INode<TStep>
     {


### PR DESCRIPTION
1. Fix missing `event` modifier on `AlgorithmProgress.ProgressChanged`.
2. Fix missing `event` modifier on `AlgorithmObserverFactory<T>.Created`.
3. Update documentation comments.