### PR TITLE
Add experimental build constant

### DIFF
--- a/src/Heuristic.Linq/Algorithms/AStar.cs
+++ b/src/Heuristic.Linq/Algorithms/AStar.cs
@@ -31,7 +31,11 @@ namespace Heuristic.Linq.Algorithms
 
             open.Sort(nc);
 
+#if HASHSET_AS_CLOSED_LIST
+            Debug.WriteLine($"Using {typeof(HashSet<TStep>).Name} as closed list.");
+
             var closed = new HashSet<TStep>(sc);
+#endif
             var sortAt = 0;
 
             while (open.Count - sortAt > 0)
@@ -43,12 +47,19 @@ namespace Heuristic.Linq.Algorithms
                     return current;
 
                 sortAt++;
+#if HASHSET_AS_CLOSED_LIST
                 closed.Add(current.Step);
-
+#endif
                 foreach (var next in source.Expands(current.Step, current.Level))
                 {
+                    // 1st if: search in closed list.
+                    // 2nd if: search in open list.
+#if HASHSET_AS_CLOSED_LIST
                     if (closed.Contains(next.Step)) continue;
-                    if (open.Find(step => sc.Equals(next.Step, step.Step)) == null)
+#else
+                    if (open.FindLastIndex(sortAt - 1, step => sc.Equals(next.Step, step.Step)) != -1) continue;
+#endif
+                    if (open.FindIndex(sortAt, step => sc.Equals(next.Step, step.Step)) == -1)
                     {
                         next.Previous = current;
 
@@ -80,7 +91,11 @@ namespace Heuristic.Linq.Algorithms
 
             open.Sort(nc);
 
+#if HASHSET_AS_CLOSED_LIST
+            Debug.WriteLine($"Using {typeof(HashSet<TStep>).Name} as closed list.");
+
             var closed = new HashSet<TStep>(sc);
+#endif
             var sortAt = 0;
 
             while (open.Count - sortAt > 0)
@@ -92,12 +107,19 @@ namespace Heuristic.Linq.Algorithms
                     return observer.Found(current, open.GetRange(sortAt, open.Count - sortAt));
 
                 sortAt++;
+#if HASHSET_AS_CLOSED_LIST
                 closed.Add(current.Step);
-
+#endif
                 foreach (var next in source.Expands(current.Step, current.Level))
                 {
+                    // 1st if: search in closed list.
+                    // 2nd if: search in open list.
+#if HASHSET_AS_CLOSED_LIST
                     if (closed.Contains(next.Step)) continue;
-                    if (open.Find(step => sc.Equals(next.Step, step.Step)) == null)
+#else
+                    if (open.FindLastIndex(sortAt - 1, step => sc.Equals(next.Step, step.Step)) != -1) continue;
+#endif
+                    if (open.FindIndex(sortAt, step => sc.Equals(next.Step, step.Step)) == -1)
                     {
                         next.Previous = current;
 


### PR DESCRIPTION
The **HASHSET_AS_CLOSED_LIST** constant will enable A* algorithm back to use `HashList<T>` as the closed list. Otherwise, the algorithm will search the node in the closed (unused) section in the open list. This could improve performance as additional actions of moving nodes from open list to closed are no longer required.