### PR TITLE
Improve usability of default implementation

### DIFF
--- a/src/Heuristic.Linq/AlgorithmObserverFactory.cs
+++ b/src/Heuristic.Linq/AlgorithmObserverFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Heuristic.Linq
 {
@@ -6,10 +7,17 @@ namespace Heuristic.Linq
 
     /// <summary>
     /// Provides the default implementation of <see cref="IAlgorithmObserverFactory{TStep}"/> interface.
-    /// </summary>
-    /// <typeparam name="TStep"></typeparam>
+    /// </summary> 
+    /// <typeparam name="TStep">The type of step of the problem.</typeparam>   
     public class AlgorithmObserverFactory<TStep> : IAlgorithmObserverFactory<TStep>
     {
+        private readonly List<AlgorithmProgress<TStep>> progresses;
+
+        /// <summary>
+        /// Gets the collection of <see cref="AlgorithmProgress{TStep}"/> instances created by the factory.
+        /// </summary>
+        public IReadOnlyList<AlgorithmProgress<TStep>> Progresses => progresses;
+
         /// <summary>
         /// Invoked when a new <see cref="AlgorithmProgress{TStep}"/> instance is created.
         /// </summary>
@@ -18,7 +26,7 @@ namespace Heuristic.Linq
         /// <summary>
         /// Initializes a new instance of current class.
         /// </summary>
-        public AlgorithmObserverFactory() { }
+        public AlgorithmObserverFactory() => progresses = new List<AlgorithmProgress<TStep>>();
 
         IProgress<AlgorithmState<TFactor, TStep>> IAlgorithmObserverFactory<TStep>.Create<TFactor>(HeuristicSearchBase<TFactor, TStep> source)
         {
@@ -35,6 +43,7 @@ namespace Heuristic.Linq
         /// <param name="progress">The new <see cref="AlgorithmProgress{TStep}"/> instance.</param>
         protected virtual void OnCreated(AlgorithmProgress<TStep> progress)
         {
+            progresses.Add(progress);
             Created?.Invoke(this, progress);
         }
     }

--- a/src/Heuristic.Linq/AlgorithmProgress.cs
+++ b/src/Heuristic.Linq/AlgorithmProgress.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Heuristic.Linq
 {
@@ -10,10 +11,19 @@ namespace Heuristic.Linq
     /// <typeparam name="TStep">The type of step of the problem.</typeparam>
     public abstract class AlgorithmProgress<TStep> : IProgress<IAlgorithmState<TStep>>
     {
+        private readonly List<IAlgorithmState<TStep>> states;
+
+        /// <summary>
+        /// Gets the collection that consists of reported states.
+        /// </summary>
+        public IReadOnlyList<IAlgorithmState<TStep>> States => states;
+
         /// <summary>
         /// Invoked when the progress of an algorithm has changed.
         /// </summary>
         public event EventHandler<IAlgorithmState<TStep>> ProgressChanged;
+
+        internal AlgorithmProgress() => states = new List<IAlgorithmState<TStep>>();
 
         void IProgress<IAlgorithmState<TStep>>.Report(IAlgorithmState<TStep> value)
         {
@@ -26,6 +36,7 @@ namespace Heuristic.Linq
         /// <param name="state">The state of an algorithm from an abstract view.</param>
         protected virtual void OnReport(IAlgorithmState<TStep> state)
         {
+            states.Add(state);
             ProgressChanged?.Invoke(this, state);
         }
     }


### PR DESCRIPTION
1. Add `AlgorithmObserverFactory<TStep>.Progresses` property that consists of `AlgorithmProgress<TStep>` instances created by the factory.
2. Add `AlgorithmProgress<TStep>.States` property that consists of reported states.
3. Update documentation comments.